### PR TITLE
Release 0.6.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,29 @@
 # Release History
 *****************
 
+## Release ONDEWO Survey Server API 0.6.0
+
+### New Features
+
+ * [[OND214-24]](https://ondewo.atlassian.net/browse/OND214-24) - Addition of the FHIR compatibility servicer
+ * [[OND214-24]](https://ondewo.atlassian.net/browse/OND214-24) - Addition of the User Identifier to the UserInformation message
+ * [[OND214-24]](https://ondewo.atlassian.net/browse/OND214-24) - Additional filters on GetSurveyAnswersRequest: "user_id" and "phone_number"
+
+*****************
 ## Release ONDEWO Survey Server API 0.5.0
 
 ### Improvements
 
- * [[OND214-14]](https://ondewo.atlassian.net/browse/OND214-13) - Add Agent Status
+ * [[OND214-14]](https://ondewo.atlassian.net/browse/OND214-14) - Add Agent Status
  * [[OND214-13]](https://ondewo.atlassian.net/browse/OND214-13) - Add user information to the extracted answers
 
+*****************
 ## Release ONDEWO Survey Server API 0.4.1
 
 ### Bug Fixes
  * [[OND214-7]](https://ondewo.atlassian.net/browse/OND214-7) - Add missing google proto dependencies 
 
+*****************
 ## Release ONDEWO Survey Server API 0.4.0
 
 ### Improvements
@@ -20,7 +31,7 @@
  * [[OND214-5]](https://ondewo.atlassian.net/browse/OND214-5) - CRUD support for Surveys
  * [[OND214-6]](https://ondewo.atlassian.net/browse/OND214-6) - Adapt to new API definition of NLU 3.x.x
 
-
+*****************
 ## Release ONDEWO Survey Server API 0.3.0
 
 ### New Features

--- a/ondewo/survey/fhir.proto
+++ b/ondewo/survey/fhir.proto
@@ -1,0 +1,59 @@
+// Copyright 2020 ONDEWO GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. (editesyntax = "proto3";
+syntax = "proto3";
+
+package ondewo.survey;
+
+import "google/api/annotations.proto";
+import "ondewo/survey/survey.proto";
+import "google/protobuf/struct.proto";
+
+/////// FHIR Services ///////
+
+// The following servicer was designed to support the FHIR standard.
+// Both Questionnaires and Responses will be detected and transformed for a simpler usage.
+
+service FHIR {
+    // Create a Survey from FHIR format and an empty NLU Agent for it
+    rpc CreateFHIRSurvey (CreateFHIRSurveyRequest) returns (Survey) {
+        option (google.api.http) = {
+            post: "/fhir_survey"
+            body: "*"
+        };
+    }
+    // Create a Survey from FHIR format and an empty NLU Agent for it
+    rpc GetFHIRSurveyAnswers (GetSurveyAnswersRequest) returns (SurveyFHIRAnswersResponse) {
+        option (google.api.http) = {
+            get: "/survey/{survey_id=*}/fhir_answers/{session_id=*}"
+        };
+    }
+    // Create a Survey from FHIR format and an empty NLU Agent for it
+    rpc GetAllFHIRSurveyAnswers (GetAllSurveyAnswersRequest) returns (SurveyFHIRAnswersResponse) {
+        option (google.api.http) = {
+            get: "/survey/{survey_id=*}/fhir_answers"
+        };
+    }
+}
+
+message CreateFHIRSurveyRequest {
+    // FHIR questionnaire on a gRPC Struct format
+    google.protobuf.Struct fhir_questionnaire = 1;
+}
+
+message SurveyFHIRAnswersResponse {
+    // The project identifier for this survey. Equal to the parent of the corresponding Agent.
+    // Format: `projects/<Project ID>/agent`.
+    string survey_id = 1;
+    repeated google.protobuf.Struct fhir_questionnaire_responses = 2; // all requested answers
+}

--- a/ondewo/survey/survey.proto
+++ b/ondewo/survey/survey.proto
@@ -346,13 +346,16 @@ message Answer {
     string answer_parameter_original = 5;
 
     message UserInfo {
+        // First name of the User to be surveyed
         string first_name = 1;
-
+        // Last name of the User to be surveyed
         string last_name = 2;
-
+        // Phone number of the User to be surveyed
         string phone_number = 3;
-
+        // the ID of the session on which the answer was collected
         string session_id = 4;
+        // Unique identifier of the User to be surveyed
+        string user_id = 5;
     }
 
     oneof is_anonymous {
@@ -391,8 +394,16 @@ message DeleteSurveyRequest {
 }
 
 message GetSurveyAnswersRequest {
-    // ID of one specific session on which survey answers were collected (contains survey_id)
-    string session_id = 1;
+    string survey_id = 1;
+
+    oneof identifier {
+        // ID of one specific session on which survey answers were collected (contains survey_id)
+        string session_id = 2;
+        // User Identifier. Note, if the survey is anonymous there will no identifier to filter on
+        string user_id = 3;
+        // User phone number. Note, if the survey is anonymous there will no identifier to filter on
+        string user_phone_number = 4;
+    }
 }
 
 message GetAllSurveyAnswersRequest {
@@ -405,7 +416,7 @@ message SurveyAnswersResponse {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: `projects/<Project ID>/agent`.
     string survey_id = 1;
-    repeated Answer answers = 2; // all the answers  for a given session id
+    repeated Answer answers = 2; // all requested answers
 }
 
 message ListSurveysRequest {


### PR DESCRIPTION
## Release ONDEWO Survey Server API 0.6.0

### New Features

 * [[OND214-24]](https://ondewo.atlassian.net/browse/OND214-24) - Addition of the FHIR compatibility servicer
 * [[OND214-24]](https://ondewo.atlassian.net/browse/OND214-24) - Addition of the User Identifier to the UserInformation message
 * [[OND214-24]](https://ondewo.atlassian.net/browse/OND214-24) - Additional filters on GetSurveyAnswersRequest: "user_id" and "phone_number"