### PR TITLE
Improve Proto Documentation Build and HTML Comment Rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,30 @@ help: ## Print usage info about help targets
 makefile_chapters: ## Shows all sections of Makefile
 	@echo `cat Makefile| grep "########################################################" -A 1 | grep -v "########################################################"`
 
+build_docs: ## Build documentation locally using the same Docker image as CI/CD
+	@echo "Building documentation using ondewo-protoc-gen-doc-action..."
+	@if [ ! -d ".tmp-protoc-gen-doc-action" ]; then \
+		echo "Cloning ondewo-protoc-gen-doc-action..."; \
+		git clone --depth 1 https://github.com/ondewo/ondewo-protoc-gen-doc-action.git .tmp-protoc-gen-doc-action; \
+	fi
+	@echo "Building Docker image with ONDEWO templates..."
+	@docker build -t ondewo-protoc-gen-doc:local .tmp-protoc-gen-doc-action
+	@echo "Generating documentation..."
+	@docker run --rm \
+		--user "$(shell id -u):$(shell id -g)" \
+		-v "$(shell pwd):/workspace" \
+		-w /workspace \
+		ondewo-protoc-gen-doc:local \
+		html,md index
+	@echo "✓ Documentation generated in docs/ directory"
+	@echo "  Open docs/index.html in your browser to view"
+
+clean_docs_builder: ## Remove the cloned protoc-gen-doc-action repo and Docker image
+	@echo "Cleaning up documentation builder..."
+	@rm -rf .tmp-protoc-gen-doc-action
+	@docker rmi ondewo-protoc-gen-doc:local 2>/dev/null || true
+	@echo "✓ Cleanup complete"
+
 TEST:
 	@echo "----------------------------------------------\nGITHUB_GH_TOKEN\n----------------------------------------------\n${GITHUB_GH_TOKEN}\n"
 	@echo "----------------------------------------------\nCURRENT_RELEASE_NOTES\n----------------------------------------------\n${CURRENT_RELEASE_NOTES}\n"

--- a/docs/index.html
+++ b/docs/index.html
@@ -246,7 +246,7 @@
       <div class="file-heading">
         <h2 id="ondewo/survey/fhir.proto">ondewo/survey/fhir.proto</h2><a href="#top">Top</a>
       </div>
-      <p>Copyright 2020 ONDEWO GmbH</p><p>Licensed under the Apache License, Version 2.0 (the "License");</p><p>you may not use this file except in compliance with the License.</p><p>You may obtain a copy of the License at</p><p>http://www.apache.org/licenses/LICENSE-2.0</p><p>Unless required by applicable law or agreed to in writing, software</p><p>distributed under the License is distributed on an "AS IS" BASIS,</p><p>WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</p><p>See the License for the specific language governing permissions and</p><p>limitations under the License. (editesyntax = "proto3";</p>
+      <p>Copyright 2020 ONDEWO GmbH</p><p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at</p><p><a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a></p><p>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. (editesyntax = "proto3";</p>
 
       
       <div id="ondewo/survey/fhir.proto-services" class="object-category">Services</div>
@@ -262,19 +262,19 @@
 
           <pre>rpc CreateFHIRSurvey (<a href="#ondewo.survey.CreateFHIRSurveyRequest">CreateFHIRSurveyRequest</a>) returns (<a href="#ondewo.survey.Survey">Survey)</a></pre>
 
-          Create a Survey from FHIR format and an empty NLU Agent for it
+          <p>Create a Survey from FHIR format and an empty NLU Agent for it</p>
         
           <h4 id="ondewo.survey.FHIR.GetFHIRSurveyAnswers" class="title-badge method">GetFHIRSurveyAnswers</h4>
 
           <pre>rpc GetFHIRSurveyAnswers (<a href="#ondewo.survey.GetSurveyAnswersRequest">GetSurveyAnswersRequest</a>) returns (<a href="#ondewo.survey.SurveyFHIRAnswersResponse">SurveyFHIRAnswersResponse)</a></pre>
 
-          Get Survey Answers on FHIR format
+          <p>Get Survey Answers on FHIR format</p>
         
           <h4 id="ondewo.survey.FHIR.GetAllFHIRSurveyAnswers" class="title-badge method">GetAllFHIRSurveyAnswers</h4>
 
           <pre>rpc GetAllFHIRSurveyAnswers (<a href="#ondewo.survey.GetAllSurveyAnswersRequest">GetAllSurveyAnswersRequest</a>) returns (<a href="#ondewo.survey.SurveyFHIRAnswersResponse">SurveyFHIRAnswersResponse)</a></pre>
 
-          Get all Survey Answers on FHIR format
+          <p>Get all Survey Answers on FHIR format</p>
         
 
         
@@ -372,7 +372,7 @@
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
-Format: `projects/<Project ID>/agent`. </p></td>
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -400,7 +400,7 @@ Format: `projects/<Project ID>/agent`. </p></td>
       <div class="file-heading">
         <h2 id="ondewo/survey/survey.proto">ondewo/survey/survey.proto</h2><a href="#top">Top</a>
       </div>
-      <p>Copyright 2020 ONDEWO GmbH</p><p>Licensed under the Apache License, Version 2.0 (the "License");</p><p>you may not use this file except in compliance with the License.</p><p>You may obtain a copy of the License at</p><p>http://www.apache.org/licenses/LICENSE-2.0</p><p>Unless required by applicable law or agreed to in writing, software</p><p>distributed under the License is distributed on an "AS IS" BASIS,</p><p>WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.</p><p>See the License for the specific language governing permissions and</p><p>limitations under the License. (editesyntax = "proto3";</p>
+      <p>Copyright 2020 ONDEWO GmbH</p><p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at</p><p><a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a></p><p>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. (editesyntax = "proto3";</p>
 
       
       <div id="ondewo/survey/survey.proto-services" class="object-category">Services</div>
@@ -416,61 +416,61 @@ Format: `projects/<Project ID>/agent`. </p></td>
 
           <pre>rpc CreateSurvey (<a href="#ondewo.survey.CreateSurveyRequest">CreateSurveyRequest</a>) returns (<a href="#ondewo.survey.Survey">Survey)</a></pre>
 
-          Create a Survey and an empty NLU Agent for it
+          <p>Create a Survey and an empty NLU Agent for it</p>
         
           <h4 id="ondewo.survey.Surveys.GetSurvey" class="title-badge method">GetSurvey</h4>
 
           <pre>rpc GetSurvey (<a href="#ondewo.survey.GetSurveyRequest">GetSurveyRequest</a>) returns (<a href="#ondewo.survey.Survey">Survey)</a></pre>
 
-          Retrieve a Survey message from the Database and return it
+          <p>Retrieve a Survey message from the Database and return it</p>
         
           <h4 id="ondewo.survey.Surveys.UpdateSurvey" class="title-badge method">UpdateSurvey</h4>
 
           <pre>rpc UpdateSurvey (<a href="#ondewo.survey.UpdateSurveyRequest">UpdateSurveyRequest</a>) returns (<a href="#ondewo.survey.Survey">Survey)</a></pre>
 
-          Update an existing Survey message from the Database and return it
+          <p>Update an existing Survey message from the Database and return it</p>
         
           <h4 id="ondewo.survey.Surveys.DeleteSurvey" class="title-badge method">DeleteSurvey</h4>
 
           <pre>rpc DeleteSurvey (<a href="#ondewo.survey.DeleteSurveyRequest">DeleteSurveyRequest</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          Delete a survey and its associated agent (if existent)
+          <p>Delete a survey and its associated agent (if existent)</p>
         
           <h4 id="ondewo.survey.Surveys.ListSurveys" class="title-badge method">ListSurveys</h4>
 
           <pre>rpc ListSurveys (<a href="#ondewo.survey.ListSurveysRequest">ListSurveysRequest</a>) returns (<a href="#ondewo.survey.ListSurveysResponse">ListSurveysResponse)</a></pre>
 
-          Returns the list of all surveys in the server
+          <p>Returns the list of all surveys in the server</p>
         
           <h4 id="ondewo.survey.Surveys.GetSurveyAnswers" class="title-badge method">GetSurveyAnswers</h4>
 
           <pre>rpc GetSurveyAnswers (<a href="#ondewo.survey.GetSurveyAnswersRequest">GetSurveyAnswersRequest</a>) returns (<a href="#ondewo.survey.SurveyAnswersResponse">SurveyAnswersResponse)</a></pre>
 
-          Retrieve answers to survey questions collected in interactions with a survey agent for a specific session
+          <p>Retrieve answers to survey questions collected in interactions with a survey agent for a specific session</p>
         
           <h4 id="ondewo.survey.Surveys.GetAllSurveyAnswers" class="title-badge method">GetAllSurveyAnswers</h4>
 
           <pre>rpc GetAllSurveyAnswers (<a href="#ondewo.survey.GetAllSurveyAnswersRequest">GetAllSurveyAnswersRequest</a>) returns (<a href="#ondewo.survey.SurveyAnswersResponse">SurveyAnswersResponse)</a></pre>
 
-          Retrieve all answers to survey questions collected in interactions with a survey agent in any session
+          <p>Retrieve all answers to survey questions collected in interactions with a survey agent in any session</p>
         
           <h4 id="ondewo.survey.Surveys.CreateAgentSurvey" class="title-badge method">CreateAgentSurvey</h4>
 
           <pre>rpc CreateAgentSurvey (<a href="#ondewo.survey.AgentSurveyRequest">AgentSurveyRequest</a>) returns (<a href="#ondewo.survey.AgentSurveyResponse">AgentSurveyResponse)</a></pre>
 
-          Populate and configures an NLU Agent from a Survey
+          <p>Populate and configures an NLU Agent from a Survey</p>
         
           <h4 id="ondewo.survey.Surveys.UpdateAgentSurvey" class="title-badge method">UpdateAgentSurvey</h4>
 
           <pre>rpc UpdateAgentSurvey (<a href="#ondewo.survey.AgentSurveyRequest">AgentSurveyRequest</a>) returns (<a href="#ondewo.survey.AgentSurveyResponse">AgentSurveyResponse)</a></pre>
 
-          Update an NLU agent from a survey
+          <p>Update an NLU agent from a survey</p>
         
           <h4 id="ondewo.survey.Surveys.DeleteAgentSurvey" class="title-badge method">DeleteAgentSurvey</h4>
 
           <pre>rpc DeleteAgentSurvey (<a href="#ondewo.survey.AgentSurveyRequest">AgentSurveyRequest</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          Deletes all data of an NLU agent associated to a survey
+          <p>Deletes all data of an NLU agent associated to a survey</p>
         
 
         
@@ -614,7 +614,7 @@ Format: `projects/<Project ID>/agent`. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
-Format: `projects/<Project ID>/agent`. </p></td>
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
             </tbody>
@@ -639,7 +639,7 @@ Format: `projects/<Project ID>/agent`. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The parent of an agent. Equal to the survey ID.
-Format: `projects/<Project ID>/agent`. </p></td>
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
             </tbody>
@@ -769,7 +769,7 @@ Optional; contains the normalized value of the selected option (parameter) extra
         
       
         <h3 id="ondewo.survey.Choice" class="title-badge message">Choice</h3>
-        <p>The Choice message defines one "option" for the SingleChoiceQuestion and MultipleChoiceQuestion question types</p><p>Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])</p>
+        <p><p>The Choice message defines one &quot;option&quot; for the SingleChoiceQuestion and MultipleChoiceQuestion question types</p></p><p><p>Example: <code>Choice(synonyms=[&quot;blue&quot;, &quot;blueish&quot;, &quot;pale blue&quot;, &quot;deep blue&quot;])</code></p></p>
 
         
           <table class="field-table">
@@ -797,7 +797,7 @@ Note: the follow-up question is only available for the SingleChoiceQuestion </p>
                   <td>value</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>The "canonical value" (i.e. the entity value) </p></td>
+                  <td><p>The &quot;canonical value&quot; (i.e. the entity value) </p></td>
                 </tr>
               
             </tbody>
@@ -846,7 +846,7 @@ Note: the follow-up question is only available for the SingleChoiceQuestion </p>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
-Format: `projects/<Project ID>/agent`. </p></td>
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
             </tbody>
@@ -871,7 +871,7 @@ Format: `projects/<Project ID>/agent`. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
-Format: `projects/<Project ID>/agent`. </p></td>
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
             </tbody>
@@ -941,7 +941,7 @@ Format: `projects/<Project ID>/agent`. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
-Format: `projects/<Project ID>/agent`. </p></td>
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
             </tbody>
@@ -967,9 +967,9 @@ Format: `projects/<Project ID>/agent`. </p></td>
                   <td></td>
                   <td><p>Optional. The next_page_token value returned from a previous list request.
 Example:
-     "current_index-10--page_size-20"
-     Start page -> 10
-     Page size -> 20 </p></td>
+<ul>
+  <li>&quot;current_index-10--page_size-20&quot; - Start page -&gt; 10, Page size -&gt; 20</li>
+</ul> </p></td>
                 </tr>
               
             </tbody>
@@ -980,7 +980,7 @@ Example:
         
       
         <h3 id="ondewo.survey.ListSurveysResponse" class="title-badge message">ListSurveysResponse</h3>
-        <p>The response message for [Intents.ListIntents][google.cloud.dialogflow.v2.Intents.ListIntents].</p>
+        <p><p>The response message for <a href="index.html#google.cloud.dialogflow.v2.Intents.ListIntents">Intents.ListIntents</a>.</p></p>
 
         
           <table class="field-table">
@@ -993,16 +993,14 @@ Example:
                   <td>surveys</td>
                   <td><a href="#ondewo.survey.Survey">Survey</a></td>
                   <td>repeated</td>
-                  <td><p>The list of surveys. There will be a maximum number of items
-returned based on the page_token field in the request. </p></td>
+                  <td><p>The list of surveys. There will be a maximum number of items returned based on the page_token field in the request. </p></td>
                 </tr>
               
                 <tr>
                   <td>next_page_token</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Token to retrieve the next page of results, or empty if there are no
-more results in the list. </p></td>
+                  <td><p>Token to retrieve the next page of results, or empty if there are no more results in the list. </p></td>
                 </tr>
               
             </tbody>
@@ -1013,7 +1011,7 @@ more results in the list. </p></td>
         
       
         <h3 id="ondewo.survey.MultipleChoiceQuestion" class="title-badge message">MultipleChoiceQuestion</h3>
-        <p>A question for which exactly one or more out of a predefined set of options are expected as answers</p><p>Example: MultipleChoiceQuestion(</p><p>question_text='Which colors do you like?',</p><p>choices=[</p><p>Choice(synonyms=['red', 'reddisch']),</p><p>Choice(synonyms=['blue', 'blueish']),</p><p>Choice(synonyms=['yellow']),</p><p>]</p><p>)</p>
+        <p><p>A question for which exactly one or more out of a predefined set of options are expected as answers</p></p><p><p>Example: <code>MultipleChoiceQuestion(question_text=&apos;Which colors do you like?&apos;, choices=[Choice(synonyms=[&apos;red&apos;, &apos;reddisch&apos;]), Choice(synonyms=[&apos;blue&apos;, &apos;blueish&apos;]), Choice(synonyms=[&apos;yellow&apos;])])</code></p></p>
 
         
           <table class="field-table">
@@ -1046,7 +1044,7 @@ Note: needs to contain at least 2 choices </p></td>
         
       
         <h3 id="ondewo.survey.MultipleParameterQuestion" class="title-badge message">MultipleParameterQuestion</h3>
-        <p>MultipleParameterQuestion defines a question which prompts the user for one or several entities of one particular type</p><p>Example: MultipleParameterQuestion(question_text='How old are your children?', parameter_type='sys.number')</p>
+        <p><p>MultipleParameterQuestion defines a question which prompts the user for one or several entities of one particular type</p></p><p><p>Example: <code>MultipleParameterQuestion(question_text=&apos;How old are your children?&apos;, parameter_type=&apos;sys.number&apos;)</code></p></p>
 
         
           <table class="field-table">
@@ -1078,7 +1076,7 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
         
       
         <h3 id="ondewo.survey.OpenQuestion" class="title-badge message">OpenQuestion</h3>
-        <p>A question to which any kind of reply can be given and recorded</p><p>fixme: not working yet</p>
+        <p><p>A question to which any kind of reply can be given and recorded</p></p><p><p>fixme: not working yet</p></p>
 
         
           <table class="field-table">
@@ -1230,7 +1228,7 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
         
       
         <h3 id="ondewo.survey.SingleChoiceQuestion" class="title-badge message">SingleChoiceQuestion</h3>
-        <p>A question for which exactly one out of a predefined set of options is expected as answer</p><p>Example: SingleChoiceQuestion(</p><p>question_text='Who is your favorite movie hero?',</p><p>choices=[</p><p>Choice(synonyms=['Bond', 'James Bond']),</p><p>Choice(synonyms=['Batman']),</p><p>Choice(synonyms=['Superman', 'Clark Kent']),</p><p>]</p><p>)</p>
+        <p><p>A question for which exactly one out of a predefined set of options is expected as answer</p></p><p><p>Example: <code>SingleChoiceQuestion(question_text=&apos;Who is your favorite movie hero?&apos;, choices=[Choice(synonyms=[&apos;Bond&apos;, &apos;James Bond&apos;]), Choice(synonyms=[&apos;Batman&apos;]), Choice(synonyms=[&apos;Superman&apos;, &apos;Clark Kent&apos;])])</code></p></p>
 
         
           <table class="field-table">
@@ -1263,7 +1261,7 @@ Note: needs to contain at least 2 choices </p></td>
         
       
         <h3 id="ondewo.survey.SingleParameterQuestion" class="title-badge message">SingleParameterQuestion</h3>
-        <p>SingleParameterQuestion defines a question which prompts the user for one entity of a particular type</p><p>Example: SingleParameterQuestion(question_text='How old are you?', parameter_type='sys.number')</p>
+        <p><p>SingleParameterQuestion defines a question which prompts the user for one entity of a particular type</p></p><p><p>Example: <code>SingleParameterQuestion(question_text=&apos;How old are you?&apos;, parameter_type=&apos;sys.number&apos;)</code></p></p>
 
         
           <table class="field-table">
@@ -1309,7 +1307,7 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
-Format: `projects/<Project ID>/agent`.
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
 Read-only in the Survey message (assigned by the back-end) </p></td>
                 </tr>
               
@@ -1326,7 +1324,6 @@ Read-only in the Survey message (assigned by the back-end) </p></td>
                   <td></td>
                   <td><p>Required. The language of the agent created for the survey.
 This is also the only supported language of the agent.
-
 ISO 639-1 language code </p></td>
                 </tr>
               
@@ -1380,7 +1377,7 @@ ISO 639-1 language code </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
-Format: `projects/<Project ID>/agent`. </p></td>
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -1398,7 +1395,7 @@ Format: `projects/<Project ID>/agent`. </p></td>
         
       
         <h3 id="ondewo.survey.SurveyInfo" class="title-badge message">SurveyInfo</h3>
-        <p>Collect information about the entity behind the survey, the purpose of the survey, legal stuff, etc.</p><p>This is needed to generate meaningful messages and training data for some of the auto-generated intents.</p>
+        <p><p>Collect information about the entity behind the survey, the purpose of the survey, legal stuff, etc.</p></p><p><p>This is needed to generate meaningful messages and training data for some of the auto-generated intents.</p></p>
 
         
           <table class="field-table">
@@ -1477,10 +1474,9 @@ A one-word explanation of the survey topic (in pronounceable form) </p></td>
                   <td></td>
                   <td><p>Required.
 A pronounceable explanation of the legal implications of participating in the survey.
-For example:
- "Your answers during this survey will be stored anonymously for the next two years and then deleted."
+For example: &quot;Your answers during this survey will be stored anonymously for the next two years and then deleted.&quot;
 Should be formulated such that the agent can afterwards ask for the consent of the user.
-Example for how the agent could continue: "Are you willing to participate in this survey?" </p></td>
+Example for how the agent could continue: &quot;Are you willing to participate in this survey?&quot; </p></td>
                 </tr>
               
                 <tr>
@@ -1521,8 +1517,7 @@ If the survey is not anonymous, the name of the people as well as their number w
                   <td><a href="#google.protobuf.FieldMask">google.protobuf.FieldMask</a></td>
                   <td></td>
                   <td><p>Optional. Field mask that defines which fields get updated. Default: all fields are updated.
-Example:
-         - update_mask = FieldMask( [ 'survey.display_name', 'survey.questions' ] ) </p></td>
+Example: <code>update_mask = FieldMask([&apos;survey.display_name&apos;, &apos;survey.questions&apos;])</code> </p></td>
                 </tr>
               
             </tbody>
@@ -1538,7 +1533,7 @@ Example:
       <div id="ondewo/survey/survey.proto-enums" class="object-category">Enums</div>
       
         <h3 id="ondewo.survey.SubFlow" class="title-badge enum">SubFlow</h3>
-        <p>Enumeration of (some of) the subflows which are created by default</p><p>This can be used to "switch off" particular subflows when creating an agent during CreateSurvey</p><p>Subflows are defined as one of the following:</p><p>- sequences of intents A -> B_1, ..., B_n -> ... -> Z_1, ..., Z_m which are linked by context relationships</p><p>such that the first intent in the sequence can always be triggered</p><p>- single intents which can always be triggered</p>
+        <p><p>Enumeration of (some of) the subflows which are created by default</p></p><p><p>This can be used to &quot;switch off&quot; particular subflows when creating an agent during CreateSurvey</p></p><p><p>Subflows are defined as one of the following:</p></p><p><ul></p><p><li>sequences of intents A -&gt; B_1, ..., B_n -&gt; ... -&gt; Z_1, ..., Z_m which are linked by context relationships such that the first intent in the sequence can always be triggered</li></p><p><li>single intents which can always be triggered</li></p><p></ul></p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -334,7 +334,7 @@
       <div id="ondewo/survey/fhir.proto-messages" class="object-category">Messages</div>
       
         <h3 id="ondewo.survey.CreateFHIRSurveyRequest" class="title-badge message">CreateFHIRSurveyRequest</h3>
-        <p></p>
+        <p>Request message for creating a survey from FHIR format</p>
 
         
           <table class="field-table">
@@ -358,7 +358,7 @@
         
       
         <h3 id="ondewo.survey.SurveyFHIRAnswersResponse" class="title-badge message">SurveyFHIRAnswersResponse</h3>
-        <p></p>
+        <p>Response message containing survey answers in FHIR format</p>
 
         
           <table class="field-table">
@@ -600,7 +600,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
       <div id="ondewo/survey/survey.proto-messages" class="object-category">Messages</div>
       
         <h3 id="ondewo.survey.AgentSurveyRequest" class="title-badge message">AgentSurveyRequest</h3>
-        <p></p>
+        <p>Request message for agent-related survey operations</p>
 
         
           <table class="field-table">
@@ -625,7 +625,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
         
       
         <h3 id="ondewo.survey.AgentSurveyResponse" class="title-badge message">AgentSurveyResponse</h3>
-        <p></p>
+        <p>Response message for agent-related survey operations</p>
 
         
           <table class="field-table">
@@ -650,7 +650,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
         
       
         <h3 id="ondewo.survey.Answer" class="title-badge message">Answer</h3>
-        <p></p>
+        <p>An answer to a survey question collected during a session</p>
 
         
           <table class="field-table">
@@ -699,14 +699,14 @@ Optional; contains the normalized value of the selected option (parameter) extra
                   <td>anonymous</td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>True if the survey is anonymous, false otherwise </p></td>
                 </tr>
               
                 <tr>
                   <td>user_information</td>
                   <td><a href="#ondewo.survey.Answer.UserInfo">Answer.UserInfo</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>User information if the survey is not anonymous </p></td>
                 </tr>
               
             </tbody>
@@ -717,7 +717,7 @@ Optional; contains the normalized value of the selected option (parameter) extra
         
       
         <h3 id="ondewo.survey.Answer.UserInfo" class="title-badge message">Answer.UserInfo</h3>
-        <p></p>
+        <p>User information for non-anonymous surveys</p>
 
         
           <table class="field-table">
@@ -808,7 +808,7 @@ Note: the follow-up question is only available for the SingleChoiceQuestion </p>
         
       
         <h3 id="ondewo.survey.CreateSurveyRequest" class="title-badge message">CreateSurveyRequest</h3>
-        <p></p>
+        <p>Request message for creating a new survey</p>
 
         
           <table class="field-table">
@@ -821,7 +821,7 @@ Note: the follow-up question is only available for the SingleChoiceQuestion </p>
                   <td>survey</td>
                   <td><a href="#ondewo.survey.Survey">Survey</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>The survey to create </p></td>
                 </tr>
               
             </tbody>
@@ -832,7 +832,7 @@ Note: the follow-up question is only available for the SingleChoiceQuestion </p>
         
       
         <h3 id="ondewo.survey.DeleteSurveyRequest" class="title-badge message">DeleteSurveyRequest</h3>
-        <p></p>
+        <p>Request message for deleting a survey</p>
 
         
           <table class="field-table">
@@ -857,7 +857,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
         
       
         <h3 id="ondewo.survey.GetAllSurveyAnswersRequest" class="title-badge message">GetAllSurveyAnswersRequest</h3>
-        <p></p>
+        <p>Request message for retrieving all survey answers</p>
 
         
           <table class="field-table">
@@ -882,7 +882,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
         
       
         <h3 id="ondewo.survey.GetSurveyAnswersRequest" class="title-badge message">GetSurveyAnswersRequest</h3>
-        <p></p>
+        <p>Request message for retrieving survey answers for a specific session or user</p>
 
         
           <table class="field-table">
@@ -895,7 +895,8 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                   <td>survey_id</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>The project identifier for this survey. Equal to the parent of the corresponding Agent.
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -927,7 +928,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
         
       
         <h3 id="ondewo.survey.GetSurveyRequest" class="title-badge message">GetSurveyRequest</h3>
-        <p></p>
+        <p>Request message for retrieving a survey</p>
 
         
           <table class="field-table">
@@ -952,7 +953,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
         
       
         <h3 id="ondewo.survey.ListSurveysRequest" class="title-badge message">ListSurveysRequest</h3>
-        <p></p>
+        <p>Request message for listing surveys with pagination support</p>
 
         
           <table class="field-table">
@@ -1100,7 +1101,7 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
         
       
         <h3 id="ondewo.survey.Question" class="title-badge message">Question</h3>
-        <p></p>
+        <p>A question that can be one of several question types: open-ended, single choice, multiple choice, scale, or parameter-based questions</p>
 
         
           <table class="field-table">
@@ -1113,21 +1114,21 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
                   <td>open_question</td>
                   <td><a href="#ondewo.survey.OpenQuestion">OpenQuestion</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>A question to which any kind of reply can be given and recorded </p></td>
                 </tr>
               
                 <tr>
                   <td>single_choice_question</td>
                   <td><a href="#ondewo.survey.SingleChoiceQuestion">SingleChoiceQuestion</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>A question for which exactly one out of a predefined set of options is expected as answer </p></td>
                 </tr>
               
                 <tr>
                   <td>multiple_choice_question</td>
                   <td><a href="#ondewo.survey.MultipleChoiceQuestion">MultipleChoiceQuestion</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>A question for which exactly one or more out of a predefined set of options are expected as answers </p></td>
                 </tr>
               
                 <tr>
@@ -1141,14 +1142,14 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
                   <td>single_parameter_question</td>
                   <td><a href="#ondewo.survey.SingleParameterQuestion">SingleParameterQuestion</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>A question for which one or more entities of a particular type are expected as answers </p></td>
                 </tr>
               
                 <tr>
                   <td>multiple_parameter_question</td>
                   <td><a href="#ondewo.survey.MultipleParameterQuestion">MultipleParameterQuestion</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>A question for which one or more entities of a particular type are expected as answers </p></td>
                 </tr>
               
             </tbody>
@@ -1179,14 +1180,14 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
                   <td>min_value</td>
                   <td><a href="#ondewo.survey.ScaleQuestion.ScaleValue">ScaleQuestion.ScaleValue</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Minimum value and label for the scale </p></td>
                 </tr>
               
                 <tr>
                   <td>max_value</td>
                   <td><a href="#ondewo.survey.ScaleQuestion.ScaleValue">ScaleQuestion.ScaleValue</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Maximum value and label for the scale </p></td>
                 </tr>
               
             </tbody>
@@ -1197,7 +1198,7 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
         
       
         <h3 id="ondewo.survey.ScaleQuestion.ScaleValue" class="title-badge message">ScaleQuestion.ScaleValue</h3>
-        <p></p>
+        <p>Represents a value and label pair for scale question endpoints</p>
 
         
           <table class="field-table">
@@ -1210,14 +1211,14 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
                   <td>value</td>
                   <td><a href="#int32">int32</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Numeric value for this scale point </p></td>
                 </tr>
               
                 <tr>
                   <td>label</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Human-readable label for this scale point </p></td>
                 </tr>
               
             </tbody>
@@ -1293,7 +1294,7 @@ Note: the corresponding entity_type must exist (system entity type) and is not a
         
       
         <h3 id="ondewo.survey.Survey" class="title-badge message">Survey</h3>
-        <p></p>
+        <p>A survey containing questions and metadata for conducting user surveys</p>
 
         
           <table class="field-table">
@@ -1363,7 +1364,7 @@ ISO 639-1 language code </p></td>
         
       
         <h3 id="ondewo.survey.SurveyAnswersResponse" class="title-badge message">SurveyAnswersResponse</h3>
-        <p></p>
+        <p>Response message containing survey answers</p>
 
         
           <table class="field-table">
@@ -1496,7 +1497,7 @@ If the survey is not anonymous, the name of the people as well as their number w
         
       
         <h3 id="ondewo.survey.UpdateSurveyRequest" class="title-badge message">UpdateSurveyRequest</h3>
-        <p></p>
+        <p>Request message for updating an existing survey</p>
 
         
           <table class="field-table">
@@ -1608,25 +1609,25 @@ Example: <code>update_mask = FieldMask([&apos;survey.display_name&apos;, &apos;s
               <tr>
                 <td>TO_BE_INITIALIZED</td>
                 <td>0</td>
-                <td><p></p></td>
+                <td><p>Agent has not been initialized yet</p></td>
               </tr>
             
               <tr>
                 <td>UPDATED</td>
                 <td>1</td>
-                <td><p></p></td>
+                <td><p>Agent has been successfully updated and is current</p></td>
               </tr>
             
               <tr>
                 <td>UPDATING</td>
                 <td>2</td>
-                <td><p></p></td>
+                <td><p>Agent is currently being updated</p></td>
               </tr>
             
               <tr>
                 <td>OUTDATED</td>
                 <td>3</td>
-                <td><p></p></td>
+                <td><p>Agent is outdated and needs to be updated</p></td>
               </tr>
             
           </tbody>

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.CreateFHIRSurveyRequest"></a>
 
 ### CreateFHIRSurveyRequest
-
+Request message for creating a survey from FHIR format
 
 
 | Field | Type | Label | Description |
@@ -75,7 +75,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.SurveyFHIRAnswersResponse"></a>
 
 ### SurveyFHIRAnswersResponse
-
+Response message containing survey answers in FHIR format
 
 
 | Field | Type | Label | Description |
@@ -125,7 +125,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.AgentSurveyRequest"></a>
 
 ### AgentSurveyRequest
-
+Request message for agent-related survey operations
 
 
 | Field | Type | Label | Description |
@@ -140,7 +140,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.AgentSurveyResponse"></a>
 
 ### AgentSurveyResponse
-
+Response message for agent-related survey operations
 
 
 | Field | Type | Label | Description |
@@ -155,7 +155,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.Answer"></a>
 
 ### Answer
-
+An answer to a survey question collected during a session
 
 
 | Field | Type | Label | Description |
@@ -165,8 +165,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 | answer_text | [string](#string) |  | Required; the full answer text |
 | answer_parameter | [string](#string) |  | fixme: better names and doc-strings below Optional; contains the normalized value of the selected option (parameter) extracted |
 | answer_parameter_original | [string](#string) |  | Optional; contains the original text of the selected option (parameter) extracted |
-| anonymous | [bool](#bool) |  |  |
-| user_information | [Answer.UserInfo](#ondewo.survey.Answer.UserInfo) |  |  |
+| anonymous | [bool](#bool) |  | True if the survey is anonymous, false otherwise |
+| user_information | [Answer.UserInfo](#ondewo.survey.Answer.UserInfo) |  | User information if the survey is not anonymous |
 
 
 
@@ -176,7 +176,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.Answer.UserInfo"></a>
 
 ### Answer.UserInfo
-
+User information for non-anonymous surveys
 
 
 | Field | Type | Label | Description |
@@ -213,12 +213,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.CreateSurveyRequest"></a>
 
 ### CreateSurveyRequest
-
+Request message for creating a new survey
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey | [Survey](#ondewo.survey.Survey) |  |  |
+| survey | [Survey](#ondewo.survey.Survey) |  | The survey to create |
 
 
 
@@ -228,7 +228,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.DeleteSurveyRequest"></a>
 
 ### DeleteSurveyRequest
-
+Request message for deleting a survey
 
 
 | Field | Type | Label | Description |
@@ -243,7 +243,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.GetAllSurveyAnswersRequest"></a>
 
 ### GetAllSurveyAnswersRequest
-
+Request message for retrieving all survey answers
 
 
 | Field | Type | Label | Description |
@@ -258,12 +258,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.GetSurveyAnswersRequest"></a>
 
 ### GetSurveyAnswersRequest
-
+Request message for retrieving survey answers for a specific session or user
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  |  |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 | session_id | [string](#string) |  | ID of one specific session on which survey answers were collected (contains survey_id) |
 | user_id | [string](#string) |  | User Identifier. Note, if the survey is anonymous there will no identifier to filter on |
 | user_phone_number | [string](#string) |  | User phone number. Note, if the survey is anonymous there will no identifier to filter on |
@@ -276,7 +276,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.GetSurveyRequest"></a>
 
 ### GetSurveyRequest
-
+Request message for retrieving a survey
 
 
 | Field | Type | Label | Description |
@@ -291,7 +291,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.ListSurveysRequest"></a>
 
 ### ListSurveysRequest
-
+Request message for listing surveys with pagination support
 
 
 | Field | Type | Label | Description |
@@ -372,17 +372,17 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <a name="ondewo.survey.Question"></a>
 
 ### Question
-
+A question that can be one of several question types: open-ended, single choice, multiple choice, scale, or parameter-based questions
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| open_question | [OpenQuestion](#ondewo.survey.OpenQuestion) |  |  |
-| single_choice_question | [SingleChoiceQuestion](#ondewo.survey.SingleChoiceQuestion) |  |  |
-| multiple_choice_question | [MultipleChoiceQuestion](#ondewo.survey.MultipleChoiceQuestion) |  |  |
+| open_question | [OpenQuestion](#ondewo.survey.OpenQuestion) |  | A question to which any kind of reply can be given and recorded |
+| single_choice_question | [SingleChoiceQuestion](#ondewo.survey.SingleChoiceQuestion) |  | A question for which exactly one out of a predefined set of options is expected as answer |
+| multiple_choice_question | [MultipleChoiceQuestion](#ondewo.survey.MultipleChoiceQuestion) |  | A question for which exactly one or more out of a predefined set of options are expected as answers |
 | scale_question | [ScaleQuestion](#ondewo.survey.ScaleQuestion) |  | convenience wrapper around a SingleChoiceQuestion |
-| single_parameter_question | [SingleParameterQuestion](#ondewo.survey.SingleParameterQuestion) |  |  |
-| multiple_parameter_question | [MultipleParameterQuestion](#ondewo.survey.MultipleParameterQuestion) |  |  |
+| single_parameter_question | [SingleParameterQuestion](#ondewo.survey.SingleParameterQuestion) |  | A question for which one or more entities of a particular type are expected as answers |
+| multiple_parameter_question | [MultipleParameterQuestion](#ondewo.survey.MultipleParameterQuestion) |  | A question for which one or more entities of a particular type are expected as answers |
 
 
 
@@ -398,8 +398,8 @@ A question for which an answer on a user-defined scale is expected
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | question_text | [string](#string) |  | The text which introduces the question (should be pronounceable) |
-| min_value | [ScaleQuestion.ScaleValue](#ondewo.survey.ScaleQuestion.ScaleValue) |  |  |
-| max_value | [ScaleQuestion.ScaleValue](#ondewo.survey.ScaleQuestion.ScaleValue) |  |  |
+| min_value | [ScaleQuestion.ScaleValue](#ondewo.survey.ScaleQuestion.ScaleValue) |  | Minimum value and label for the scale |
+| max_value | [ScaleQuestion.ScaleValue](#ondewo.survey.ScaleQuestion.ScaleValue) |  | Maximum value and label for the scale |
 
 
 
@@ -409,13 +409,13 @@ A question for which an answer on a user-defined scale is expected
 <a name="ondewo.survey.ScaleQuestion.ScaleValue"></a>
 
 ### ScaleQuestion.ScaleValue
-
+Represents a value and label pair for scale question endpoints
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| value | [int32](#int32) |  |  |
-| label | [string](#string) |  |  |
+| value | [int32](#int32) |  | Numeric value for this scale point |
+| label | [string](#string) |  | Human-readable label for this scale point |
 
 
 
@@ -459,7 +459,7 @@ A question for which an answer on a user-defined scale is expected
 <a name="ondewo.survey.Survey"></a>
 
 ### Survey
-
+A survey containing questions and metadata for conducting user surveys
 
 
 | Field | Type | Label | Description |
@@ -480,7 +480,7 @@ A question for which an answer on a user-defined scale is expected
 <a name="ondewo.survey.SurveyAnswersResponse"></a>
 
 ### SurveyAnswersResponse
-
+Response message containing survey answers
 
 
 | Field | Type | Label | Description |
@@ -521,7 +521,7 @@ A question for which an answer on a user-defined scale is expected
 <a name="ondewo.survey.UpdateSurveyRequest"></a>
 
 ### UpdateSurveyRequest
-
+Request message for updating an existing survey
 
 
 | Field | Type | Label | Description |
@@ -568,10 +568,10 @@ A question for which an answer on a user-defined scale is expected
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| TO_BE_INITIALIZED | 0 |  |
-| UPDATED | 1 |  |
-| UPDATING | 2 |  |
-| OUTDATED | 3 |  |
+| TO_BE_INITIALIZED | 0 | Agent has not been initialized yet |
+| UPDATED | 1 | Agent has been successfully updated and is current |
+| UPDATING | 2 | Agent is currently being updated |
+| OUTDATED | 3 | Agent is outdated and needs to be updated |
 
 
  <!-- end enums -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,17 +50,11 @@
 ## ondewo/survey/fhir.proto
 Copyright 2020 ONDEWO GmbH
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. (editesyntax = "proto3";
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. (editesyntax = "proto3";
 
 
 <a name="ondewo.survey.CreateFHIRSurveyRequest"></a>
@@ -86,7 +80,7 @@ limitations under the License. (editesyntax = "proto3";
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: `projects/<Project ID>/agent`. |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 | fhir_questionnaire_responses | [google.protobuf.Struct](#google.protobuf.Struct) | repeated | all requested answers |
 
 
@@ -107,9 +101,9 @@ limitations under the License. (editesyntax = "proto3";
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateFHIRSurvey | [CreateFHIRSurveyRequest](#ondewo.survey.CreateFHIRSurveyRequest) | [Survey](#ondewo.survey.Survey) | Create a Survey from FHIR format and an empty NLU Agent for it |
-| GetFHIRSurveyAnswers | [GetSurveyAnswersRequest](#ondewo.survey.GetSurveyAnswersRequest) | [SurveyFHIRAnswersResponse](#ondewo.survey.SurveyFHIRAnswersResponse) | Get Survey Answers on FHIR format |
-| GetAllFHIRSurveyAnswers | [GetAllSurveyAnswersRequest](#ondewo.survey.GetAllSurveyAnswersRequest) | [SurveyFHIRAnswersResponse](#ondewo.survey.SurveyFHIRAnswersResponse) | Get all Survey Answers on FHIR format |
+| CreateFHIRSurvey | [CreateFHIRSurveyRequest](#ondewo.survey.CreateFHIRSurveyRequest) | [Survey](#ondewo.survey.Survey) | <p>Create a Survey from FHIR format and an empty NLU Agent for it</p> |
+| GetFHIRSurveyAnswers | [GetSurveyAnswersRequest](#ondewo.survey.GetSurveyAnswersRequest) | [SurveyFHIRAnswersResponse](#ondewo.survey.SurveyFHIRAnswersResponse) | <p>Get Survey Answers on FHIR format</p> |
+| GetAllFHIRSurveyAnswers | [GetAllSurveyAnswersRequest](#ondewo.survey.GetAllSurveyAnswersRequest) | [SurveyFHIRAnswersResponse](#ondewo.survey.SurveyFHIRAnswersResponse) | <p>Get all Survey Answers on FHIR format</p> |
 
  <!-- end services -->
 
@@ -121,17 +115,11 @@ limitations under the License. (editesyntax = "proto3";
 ## ondewo/survey/survey.proto
 Copyright 2020 ONDEWO GmbH
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License. (editesyntax = "proto3";
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. (editesyntax = "proto3";
 
 
 <a name="ondewo.survey.AgentSurveyRequest"></a>
@@ -142,7 +130,7 @@ limitations under the License. (editesyntax = "proto3";
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: `projects/<Project ID>/agent`. |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 
 
 
@@ -157,7 +145,7 @@ limitations under the License. (editesyntax = "proto3";
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parent | [string](#string) |  | The parent of an agent. Equal to the survey ID. Format: `projects/<Project ID>/agent`. |
+| parent | [string](#string) |  | The parent of an agent. Equal to the survey ID. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 
 
 
@@ -207,15 +195,15 @@ limitations under the License. (editesyntax = "proto3";
 <a name="ondewo.survey.Choice"></a>
 
 ### Choice
-The Choice message defines one "option" for the SingleChoiceQuestion and MultipleChoiceQuestion question types
-Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])
+<p>The Choice message defines one &quot;option&quot; for the SingleChoiceQuestion and MultipleChoiceQuestion question types</p>
+<p>Example: <code>Choice(synonyms=[&quot;blue&quot;, &quot;blueish&quot;, &quot;pale blue&quot;, &quot;deep blue&quot;])</code></p>
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | synonyms | [string](#string) | repeated | The synonyms which are recognized as equivalent for identifying one option |
 | follow_up_question | [Question](#ondewo.survey.Question) |  | Optional; Nested question if this specific choice gets chosen. Note: the follow-up question is only available for the SingleChoiceQuestion |
-| value | [string](#string) |  | The "canonical value" (i.e. the entity value) |
+| value | [string](#string) |  | The &quot;canonical value&quot; (i.e. the entity value) |
 
 
 
@@ -245,7 +233,7 @@ Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: `projects/<Project ID>/agent`. |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 
 
 
@@ -260,7 +248,7 @@ Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: `projects/<Project ID>/agent`. |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 
 
 
@@ -293,7 +281,7 @@ Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: `projects/<Project ID>/agent`. |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 
 
 
@@ -308,7 +296,7 @@ Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| page_token | [string](#string) |  | Optional. The next_page_token value returned from a previous list request. Example: "current_index-10--page_size-20" Start page -> 10 Page size -> 20 |
+| page_token | [string](#string) |  | Optional. The next_page_token value returned from a previous list request. Example: <ul> <li>&quot;current_index-10--page_size-20&quot; - Start page -&gt; 10, Page size -&gt; 20</li> </ul> |
 
 
 
@@ -318,7 +306,7 @@ Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])
 <a name="ondewo.survey.ListSurveysResponse"></a>
 
 ### ListSurveysResponse
-The response message for [Intents.ListIntents][google.cloud.dialogflow.v2.Intents.ListIntents].
+<p>The response message for <a href="index.html#google.cloud.dialogflow.v2.Intents.ListIntents">Intents.ListIntents</a>.</p>
 
 
 | Field | Type | Label | Description |
@@ -334,15 +322,8 @@ The response message for [Intents.ListIntents][google.cloud.dialogflow.v2.Intent
 <a name="ondewo.survey.MultipleChoiceQuestion"></a>
 
 ### MultipleChoiceQuestion
-A question for which exactly one or more out of a predefined set of options are expected as answers
-Example: MultipleChoiceQuestion(
-     question_text='Which colors do you like?',
-     choices=[
-         Choice(synonyms=['red', 'reddisch']),
-         Choice(synonyms=['blue', 'blueish']),
-         Choice(synonyms=['yellow']),
-         ]
-      )
+<p>A question for which exactly one or more out of a predefined set of options are expected as answers</p>
+<p>Example: <code>MultipleChoiceQuestion(question_text=&apos;Which colors do you like?&apos;, choices=[Choice(synonyms=[&apos;red&apos;, &apos;reddisch&apos;]), Choice(synonyms=[&apos;blue&apos;, &apos;blueish&apos;]), Choice(synonyms=[&apos;yellow&apos;])])</code></p>
 
 
 | Field | Type | Label | Description |
@@ -358,8 +339,8 @@ Example: MultipleChoiceQuestion(
 <a name="ondewo.survey.MultipleParameterQuestion"></a>
 
 ### MultipleParameterQuestion
-MultipleParameterQuestion defines a question which prompts the user for one or several entities of one particular type
-Example: MultipleParameterQuestion(question_text='How old are your children?', parameter_type='sys.number')
+<p>MultipleParameterQuestion defines a question which prompts the user for one or several entities of one particular type</p>
+<p>Example: <code>MultipleParameterQuestion(question_text=&apos;How old are your children?&apos;, parameter_type=&apos;sys.number&apos;)</code></p>
 
 
 | Field | Type | Label | Description |
@@ -375,8 +356,8 @@ Example: MultipleParameterQuestion(question_text='How old are your children?', p
 <a name="ondewo.survey.OpenQuestion"></a>
 
 ### OpenQuestion
-A question to which any kind of reply can be given and recorded
-fixme: not working yet
+<p>A question to which any kind of reply can be given and recorded</p>
+<p>fixme: not working yet</p>
 
 
 | Field | Type | Label | Description |
@@ -444,15 +425,8 @@ A question for which an answer on a user-defined scale is expected
 <a name="ondewo.survey.SingleChoiceQuestion"></a>
 
 ### SingleChoiceQuestion
-A question for which exactly one out of a predefined set of options is expected as answer
-Example: SingleChoiceQuestion(
-     question_text='Who is your favorite movie hero?',
-     choices=[
-         Choice(synonyms=['Bond', 'James Bond']),
-         Choice(synonyms=['Batman']),
-         Choice(synonyms=['Superman', 'Clark Kent']),
-         ]
-     )
+<p>A question for which exactly one out of a predefined set of options is expected as answer</p>
+<p>Example: <code>SingleChoiceQuestion(question_text=&apos;Who is your favorite movie hero?&apos;, choices=[Choice(synonyms=[&apos;Bond&apos;, &apos;James Bond&apos;]), Choice(synonyms=[&apos;Batman&apos;]), Choice(synonyms=[&apos;Superman&apos;, &apos;Clark Kent&apos;])])</code></p>
 
 
 | Field | Type | Label | Description |
@@ -468,8 +442,8 @@ Example: SingleChoiceQuestion(
 <a name="ondewo.survey.SingleParameterQuestion"></a>
 
 ### SingleParameterQuestion
-SingleParameterQuestion defines a question which prompts the user for one entity of a particular type
-Example: SingleParameterQuestion(question_text='How old are you?', parameter_type='sys.number')
+<p>SingleParameterQuestion defines a question which prompts the user for one entity of a particular type</p>
+<p>Example: <code>SingleParameterQuestion(question_text=&apos;How old are you?&apos;, parameter_type=&apos;sys.number&apos;)</code></p>
 
 
 | Field | Type | Label | Description |
@@ -490,11 +464,9 @@ Example: SingleParameterQuestion(question_text='How old are you?', parameter_typ
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: `projects/<Project ID>/agent`. Read-only in the Survey message (assigned by the back-end) |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> Read-only in the Survey message (assigned by the back-end) |
 | display_name | [string](#string) |  | Required. The (human readable) name of this survey |
-| language_code | [string](#string) |  | Required. The language of the agent created for the survey. This is also the only supported language of the agent.
-
-ISO 639-1 language code |
+| language_code | [string](#string) |  | Required. The language of the agent created for the survey. This is also the only supported language of the agent. ISO 639-1 language code |
 | questions | [Question](#ondewo.survey.Question) | repeated | Required. List of questions to be asked during the survey. |
 | survey_info | [SurveyInfo](#ondewo.survey.SurveyInfo) |  | Required. Information about the entity behind the survey, the purpose of the survey, legal stuff, etc. |
 | exclude_subflows | [SubFlow](#ondewo.survey.SubFlow) | repeated | Optional. List of subflows excluded for this survey. |
@@ -513,7 +485,7 @@ ISO 639-1 language code |
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: `projects/<Project ID>/agent`. |
+| survey_id | [string](#string) |  | The project identifier for this survey. Equal to the parent of the corresponding Agent. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 | answers | [Answer](#ondewo.survey.Answer) | repeated | all requested answers |
 
 
@@ -524,8 +496,8 @@ ISO 639-1 language code |
 <a name="ondewo.survey.SurveyInfo"></a>
 
 ### SurveyInfo
-Collect information about the entity behind the survey, the purpose of the survey, legal stuff, etc.
-This is needed to generate meaningful messages and training data for some of the auto-generated intents.
+<p>Collect information about the entity behind the survey, the purpose of the survey, legal stuff, etc.</p>
+<p>This is needed to generate meaningful messages and training data for some of the auto-generated intents.</p>
 
 
 | Field | Type | Label | Description |
@@ -538,7 +510,7 @@ This is needed to generate meaningful messages and training data for some of the
 | expected_duration | [string](#string) |  | Required unless SubFlow.EXPECTED_DURATION is deselected. The expected duration of the survey (in pronounceable form) |
 | purpose | [string](#string) |  | Required unless SubFlow.PURPOSE is deselected. An explanation regarding the purpose of the survey (in pronounceable form) |
 | topic | [string](#string) |  | Required. A one-word explanation of the survey topic (in pronounceable form) |
-| legal_disclaimer | [string](#string) |  | Required. A pronounceable explanation of the legal implications of participating in the survey. For example: "Your answers during this survey will be stored anonymously for the next two years and then deleted." Should be formulated such that the agent can afterwards ask for the consent of the user. Example for how the agent could continue: "Are you willing to participate in this survey?" |
+| legal_disclaimer | [string](#string) |  | Required. A pronounceable explanation of the legal implications of participating in the survey. For example: &quot;Your answers during this survey will be stored anonymously for the next two years and then deleted.&quot; Should be formulated such that the agent can afterwards ask for the consent of the user. Example for how the agent could continue: &quot;Are you willing to participate in this survey?&quot; |
 | anonymous | [bool](#bool) |  | Optional. Defaults to False. Allows the definition of a survey as anonymous or not. If the survey is not anonymous, the name of the people as well as their number will be recorded |
 
 
@@ -555,7 +527,7 @@ This is needed to generate meaningful messages and training data for some of the
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | survey | [Survey](#ondewo.survey.Survey) |  | Updated survey. Note: the ID must refer to an existing survey which will be updated |
-| update_mask | [google.protobuf.FieldMask](#google.protobuf.FieldMask) |  | Optional. Field mask that defines which fields get updated. Default: all fields are updated. Example: - update_mask = FieldMask( [ 'survey.display_name', 'survey.questions' ] ) |
+| update_mask | [google.protobuf.FieldMask](#google.protobuf.FieldMask) |  | Optional. Field mask that defines which fields get updated. Default: all fields are updated. Example: <code>update_mask = FieldMask([&apos;survey.display_name&apos;, &apos;survey.questions&apos;])</code> |
 
 
 
@@ -567,12 +539,13 @@ This is needed to generate meaningful messages and training data for some of the
 <a name="ondewo.survey.SubFlow"></a>
 
 ### SubFlow
-Enumeration of (some of) the subflows which are created by default
-This can be used to "switch off" particular subflows when creating an agent during CreateSurvey
-Subflows are defined as one of the following:
-- sequences of intents A -> B_1, ..., B_n -> ... -> Z_1, ..., Z_m which are linked by context relationships
-     such that the first intent in the sequence can always be triggered
-- single intents which can always be triggered
+<p>Enumeration of (some of) the subflows which are created by default</p>
+<p>This can be used to &quot;switch off&quot; particular subflows when creating an agent during CreateSurvey</p>
+<p>Subflows are defined as one of the following:</p>
+<ul>
+  <li>sequences of intents A -&gt; B_1, ..., B_n -&gt; ... -&gt; Z_1, ..., Z_m which are linked by context relationships such that the first intent in the sequence can always be triggered</li>
+  <li>single intents which can always be triggered</li>
+</ul>
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -613,16 +586,16 @@ Subflows are defined as one of the following:
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateSurvey | [CreateSurveyRequest](#ondewo.survey.CreateSurveyRequest) | [Survey](#ondewo.survey.Survey) | Create a Survey and an empty NLU Agent for it |
-| GetSurvey | [GetSurveyRequest](#ondewo.survey.GetSurveyRequest) | [Survey](#ondewo.survey.Survey) | Retrieve a Survey message from the Database and return it |
-| UpdateSurvey | [UpdateSurveyRequest](#ondewo.survey.UpdateSurveyRequest) | [Survey](#ondewo.survey.Survey) | Update an existing Survey message from the Database and return it |
-| DeleteSurvey | [DeleteSurveyRequest](#ondewo.survey.DeleteSurveyRequest) | [.google.protobuf.Empty](#google.protobuf.Empty) | Delete a survey and its associated agent (if existent) |
-| ListSurveys | [ListSurveysRequest](#ondewo.survey.ListSurveysRequest) | [ListSurveysResponse](#ondewo.survey.ListSurveysResponse) | Returns the list of all surveys in the server |
-| GetSurveyAnswers | [GetSurveyAnswersRequest](#ondewo.survey.GetSurveyAnswersRequest) | [SurveyAnswersResponse](#ondewo.survey.SurveyAnswersResponse) | Retrieve answers to survey questions collected in interactions with a survey agent for a specific session |
-| GetAllSurveyAnswers | [GetAllSurveyAnswersRequest](#ondewo.survey.GetAllSurveyAnswersRequest) | [SurveyAnswersResponse](#ondewo.survey.SurveyAnswersResponse) | Retrieve all answers to survey questions collected in interactions with a survey agent in any session |
-| CreateAgentSurvey | [AgentSurveyRequest](#ondewo.survey.AgentSurveyRequest) | [AgentSurveyResponse](#ondewo.survey.AgentSurveyResponse) | Populate and configures an NLU Agent from a Survey |
-| UpdateAgentSurvey | [AgentSurveyRequest](#ondewo.survey.AgentSurveyRequest) | [AgentSurveyResponse](#ondewo.survey.AgentSurveyResponse) | Update an NLU agent from a survey |
-| DeleteAgentSurvey | [AgentSurveyRequest](#ondewo.survey.AgentSurveyRequest) | [.google.protobuf.Empty](#google.protobuf.Empty) | Deletes all data of an NLU agent associated to a survey |
+| CreateSurvey | [CreateSurveyRequest](#ondewo.survey.CreateSurveyRequest) | [Survey](#ondewo.survey.Survey) | <p>Create a Survey and an empty NLU Agent for it</p> |
+| GetSurvey | [GetSurveyRequest](#ondewo.survey.GetSurveyRequest) | [Survey](#ondewo.survey.Survey) | <p>Retrieve a Survey message from the Database and return it</p> |
+| UpdateSurvey | [UpdateSurveyRequest](#ondewo.survey.UpdateSurveyRequest) | [Survey](#ondewo.survey.Survey) | <p>Update an existing Survey message from the Database and return it</p> |
+| DeleteSurvey | [DeleteSurveyRequest](#ondewo.survey.DeleteSurveyRequest) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Delete a survey and its associated agent (if existent)</p> |
+| ListSurveys | [ListSurveysRequest](#ondewo.survey.ListSurveysRequest) | [ListSurveysResponse](#ondewo.survey.ListSurveysResponse) | <p>Returns the list of all surveys in the server</p> |
+| GetSurveyAnswers | [GetSurveyAnswersRequest](#ondewo.survey.GetSurveyAnswersRequest) | [SurveyAnswersResponse](#ondewo.survey.SurveyAnswersResponse) | <p>Retrieve answers to survey questions collected in interactions with a survey agent for a specific session</p> |
+| GetAllSurveyAnswers | [GetAllSurveyAnswersRequest](#ondewo.survey.GetAllSurveyAnswersRequest) | [SurveyAnswersResponse](#ondewo.survey.SurveyAnswersResponse) | <p>Retrieve all answers to survey questions collected in interactions with a survey agent in any session</p> |
+| CreateAgentSurvey | [AgentSurveyRequest](#ondewo.survey.AgentSurveyRequest) | [AgentSurveyResponse](#ondewo.survey.AgentSurveyResponse) | <p>Populate and configures an NLU Agent from a Survey</p> |
+| UpdateAgentSurvey | [AgentSurveyRequest](#ondewo.survey.AgentSurveyRequest) | [AgentSurveyResponse](#ondewo.survey.AgentSurveyResponse) | <p>Update an NLU agent from a survey</p> |
+| DeleteAgentSurvey | [AgentSurveyRequest](#ondewo.survey.AgentSurveyRequest) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Deletes all data of an NLU agent associated to a survey</p> |
 
  <!-- end services -->
 

--- a/ondewo/survey/fhir.proto
+++ b/ondewo/survey/fhir.proto
@@ -42,11 +42,13 @@ service FHIR {
     }
 }
 
+// Request message for creating a survey from FHIR format
 message CreateFHIRSurveyRequest {
     // FHIR questionnaire on a gRPC Struct format
     google.protobuf.Struct fhir_questionnaire = 1;
 }
 
+// Response message containing survey answers in FHIR format
 message SurveyFHIRAnswersResponse {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>

--- a/ondewo/survey/fhir.proto
+++ b/ondewo/survey/fhir.proto
@@ -1,16 +1,10 @@
 // Copyright 2020 ONDEWO GmbH
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License. (editesyntax = "proto3";
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. (editesyntax = "proto3";
 syntax = "proto3";
 
 package ondewo.survey;
@@ -21,11 +15,11 @@ import "google/protobuf/struct.proto";
 
 /////// FHIR Services ///////
 
-// The following servicer was designed to support the FHIR standard.
-// Both Questionnaires and Responses will be detected and transformed for a simpler usage.
+// <p>The following servicer was designed to support the FHIR standard.</p>
+// <p>Both Questionnaires and Responses will be detected and transformed for a simpler usage.</p>
 
 service FHIR {
-    // Create a Survey from FHIR format and an empty NLU Agent for it
+    // <p>Create a Survey from FHIR format and an empty NLU Agent for it</p>
     rpc CreateFHIRSurvey (CreateFHIRSurveyRequest) returns (Survey) {
         option (google.api.http) = {
             post: "/fhir_survey"
@@ -33,14 +27,14 @@ service FHIR {
         };
     }
 
-    // Get Survey Answers on FHIR format
+    // <p>Get Survey Answers on FHIR format</p>
     rpc GetFHIRSurveyAnswers (GetSurveyAnswersRequest) returns (SurveyFHIRAnswersResponse) {
         option (google.api.http) = {
             get: "/survey/{survey_id=*}/fhir_answers/{session_id=*}"
         };
     }
 
-    // Get all Survey Answers on FHIR format
+    // <p>Get all Survey Answers on FHIR format</p>
     rpc GetAllFHIRSurveyAnswers (GetAllSurveyAnswersRequest) returns (SurveyFHIRAnswersResponse) {
         option (google.api.http) = {
             get: "/survey/{survey_id=*}/fhir_answers"
@@ -55,7 +49,8 @@ message CreateFHIRSurveyRequest {
 
 message SurveyFHIRAnswersResponse {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
-    repeated google.protobuf.Struct fhir_questionnaire_responses = 2; // all requested answers
+    // all requested answers
+    repeated google.protobuf.Struct fhir_questionnaire_responses = 2;
 }

--- a/ondewo/survey/survey.proto
+++ b/ondewo/survey/survey.proto
@@ -93,6 +93,7 @@ service Surveys {
 
 /////// Core Messages ///////
 
+// A survey containing questions and metadata for conducting user surveys
 message Survey {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
@@ -119,9 +120,13 @@ message Survey {
     // Note: All other attributes of the Agent message should be updated using the std mechanism of UpdateAgent once the survey has been created.
 
     enum AgentStatus {
+        // Agent has not been initialized yet
         TO_BE_INITIALIZED = 0;
+        // Agent has been successfully updated and is current
         UPDATED = 1;
+        // Agent is currently being updated
         UPDATING = 2;
+        // Agent is outdated and needs to be updated
         OUTDATED = 3;
     }
 
@@ -217,14 +222,20 @@ enum SubFlow {
 
 }
 
+// A question that can be one of several question types: open-ended, single choice, multiple choice, scale, or parameter-based questions
 message Question {
     oneof question {
+        // A question to which any kind of reply can be given and recorded
         OpenQuestion open_question = 1;
+        // A question for which exactly one out of a predefined set of options is expected as answer
         SingleChoiceQuestion single_choice_question = 2;
+        // A question for which exactly one or more out of a predefined set of options are expected as answers
         MultipleChoiceQuestion multiple_choice_question = 3;
         // convenience wrapper around a SingleChoiceQuestion
         ScaleQuestion scale_question = 4;
+        // A question for which one or more entities of a particular type are expected as answers
         SingleParameterQuestion single_parameter_question = 5;
+        // A question for which one or more entities of a particular type are expected as answers
         MultipleParameterQuestion multiple_parameter_question = 6;
     }
 }
@@ -263,13 +274,18 @@ message MultipleChoiceQuestion {
 
 // A question for which an answer on a user-defined scale is expected
 message ScaleQuestion {
+    // Represents a value and label pair for scale question endpoints
     message ScaleValue {
+        // Numeric value for this scale point
         int32 value = 1;
+        // Human-readable label for this scale point
         string label = 2;
     }
     // The text which introduces the question (should be pronounceable)
     string question_text = 1;
+    // Minimum value and label for the scale
     ScaleValue min_value = 2;
+    // Maximum value and label for the scale
     ScaleValue max_value = 3;
 }
 
@@ -309,6 +325,7 @@ message Choice {
     string value = 3;
 }
 
+// An answer to a survey question collected during a session
 message Answer {
     // the number of the question to which this answer belongs
     int64 question_nr = 1;
@@ -326,6 +343,7 @@ message Answer {
     // Optional; contains the original text of the selected option (parameter) extracted
     string answer_parameter_original = 5;
 
+    // User information for non-anonymous surveys
     message UserInfo {
         // First name of the User to be surveyed
         string first_name = 1;
@@ -340,7 +358,9 @@ message Answer {
     }
 
     oneof is_anonymous {
+        // True if the survey is anonymous, false otherwise
         bool anonymous = 7;
+        // User information if the survey is not anonymous
         UserInfo user_information = 6;
     }
 }
@@ -348,16 +368,20 @@ message Answer {
 
 /////// Request / Response messages ///////
 
+// Request message for creating a new survey
 message CreateSurveyRequest {
+    // The survey to create
     Survey survey = 1;
 }
 
+// Request message for retrieving a survey
 message GetSurveyRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
+// Request message for updating an existing survey
 message UpdateSurveyRequest {
     // Updated survey. Note: the ID must refer to an existing survey which will be updated
     Survey survey = 1;
@@ -367,13 +391,17 @@ message UpdateSurveyRequest {
     google.protobuf.FieldMask update_mask = 2;
 }
 
+// Request message for deleting a survey
 message DeleteSurveyRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
+// Request message for retrieving survey answers for a specific session or user
 message GetSurveyAnswersRequest {
+    // The project identifier for this survey. Equal to the parent of the corresponding Agent.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 
     oneof identifier {
@@ -386,12 +414,14 @@ message GetSurveyAnswersRequest {
     }
 }
 
+// Request message for retrieving all survey answers
 message GetAllSurveyAnswersRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
+// Response message containing survey answers
 message SurveyAnswersResponse {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
@@ -400,6 +430,7 @@ message SurveyAnswersResponse {
     repeated Answer answers = 2;
 }
 
+// Request message for listing surveys with pagination support
 message ListSurveysRequest {
     // Optional. The next_page_token value returned from a previous list request.
     // Example:
@@ -418,12 +449,14 @@ message ListSurveysResponse {
     string next_page_token = 2;
 }
 
+// Request message for agent-related survey operations
 message AgentSurveyRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
+// Response message for agent-related survey operations
 message AgentSurveyResponse {
     // The parent of an agent. Equal to the survey ID.
     // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>

--- a/ondewo/survey/survey.proto
+++ b/ondewo/survey/survey.proto
@@ -1,16 +1,10 @@
 // Copyright 2020 ONDEWO GmbH
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License. (editesyntax = "proto3";
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. (editesyntax = "proto3";
 syntax = "proto3";
 
 package ondewo.survey;
@@ -22,7 +16,7 @@ import "google/protobuf/field_mask.proto";
 /////// Services ///////
 
 service Surveys {
-    // Create a Survey and an empty NLU Agent for it
+    // <p>Create a Survey and an empty NLU Agent for it</p>
     rpc CreateSurvey (CreateSurveyRequest) returns (Survey) {
         option (google.api.http) = {
             post: "/survey"
@@ -30,14 +24,14 @@ service Surveys {
         };
     }
 
-    // Retrieve a Survey message from the Database and return it
+    // <p>Retrieve a Survey message from the Database and return it</p>
     rpc GetSurvey (GetSurveyRequest) returns (Survey) {
         option (google.api.http) = {
             get: "/survey/{survey_id=*}"
         };
     }
 
-    // Update an existing Survey message from the Database and return it
+    // <p>Update an existing Survey message from the Database and return it</p>
     rpc UpdateSurvey (UpdateSurveyRequest) returns (Survey) {
         option (google.api.http) = {
             patch: "/survey/{survey_id=*}"
@@ -45,35 +39,35 @@ service Surveys {
         };
     }
 
-    // Delete a survey and its associated agent (if existent)
+    // <p>Delete a survey and its associated agent (if existent)</p>
     rpc DeleteSurvey (DeleteSurveyRequest) returns (google.protobuf.Empty) {
         option (google.api.http) = {
             delete: "/survey/{survey_id=*}"
         };
     }
 
-    // Returns the list of all surveys in the server
+    // <p>Returns the list of all surveys in the server</p>
     rpc ListSurveys (ListSurveysRequest) returns (ListSurveysResponse) {
         option (google.api.http) = {
             get: "/surveys"
         };
     }
 
-    // Retrieve answers to survey questions collected in interactions with a survey agent for a specific session
+    // <p>Retrieve answers to survey questions collected in interactions with a survey agent for a specific session</p>
     rpc GetSurveyAnswers (GetSurveyAnswersRequest) returns (SurveyAnswersResponse) {
         option (google.api.http) = {
             get: "/survey/{survey_id=*}/answers/{session_id=*}"
         };
     }
 
-    // Retrieve all answers to survey questions collected in interactions with a survey agent in any session
+    // <p>Retrieve all answers to survey questions collected in interactions with a survey agent in any session</p>
     rpc GetAllSurveyAnswers (GetAllSurveyAnswersRequest) returns (SurveyAnswersResponse) {
         option (google.api.http) = {
             get: "/survey/{survey_id=*}/answers"
         };
     }
 
-    // Populate and configures an NLU Agent from a Survey
+    // <p>Populate and configures an NLU Agent from a Survey</p>
     rpc CreateAgentSurvey (AgentSurveyRequest) returns (AgentSurveyResponse) {
         option (google.api.http) = {
             post: "/survey/{survey_id=*}/agent"
@@ -81,7 +75,7 @@ service Surveys {
         };
     }
 
-    // Update an NLU agent from a survey
+    // <p>Update an NLU agent from a survey</p>
     rpc UpdateAgentSurvey (AgentSurveyRequest) returns (AgentSurveyResponse) {
         option (google.api.http) = {
             patch: "/survey/{survey_id=*}/agent"
@@ -89,7 +83,7 @@ service Surveys {
         };
     }
 
-    // Deletes all data of an NLU agent associated to a survey
+    // <p>Deletes all data of an NLU agent associated to a survey</p>
     rpc DeleteAgentSurvey (AgentSurveyRequest) returns (google.protobuf.Empty) {
         option (google.api.http) = {
             delete: "/survey/{survey_id=*}/agent/delete"
@@ -101,7 +95,7 @@ service Surveys {
 
 message Survey {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     // Read-only in the Survey message (assigned by the back-end)
     string survey_id = 1;
 
@@ -110,7 +104,8 @@ message Survey {
 
     // Required. The language of the agent created for the survey.
     // This is also the only supported language of the agent.
-    string language_code = 3; // ISO 639-1 language code
+    // ISO 639-1 language code
+    string language_code = 3;
 
     // Required. List of questions to be asked during the survey.
     repeated Question questions = 7;
@@ -121,8 +116,7 @@ message Survey {
     // Optional. List of subflows excluded for this survey.
     repeated SubFlow exclude_subflows = 9;
 
-    // Note: All other attributes of the Agent message should be updated using the std mechanism of UpdateAgent
-    //  once the survey has been created.
+    // Note: All other attributes of the Agent message should be updated using the std mechanism of UpdateAgent once the survey has been created.
 
     enum AgentStatus {
         TO_BE_INITIALIZED = 0;
@@ -135,8 +129,8 @@ message Survey {
     AgentStatus status = 10;
 }
 
-// Collect information about the entity behind the survey, the purpose of the survey, legal stuff, etc.
-// This is needed to generate meaningful messages and training data for some of the auto-generated intents.
+// <p>Collect information about the entity behind the survey, the purpose of the survey, legal stuff, etc.</p>
+// <p>This is needed to generate meaningful messages and training data for some of the auto-generated intents.</p>
 message SurveyInfo {
 
     // Required unless SubFlow.LEGAL_ENTITY is deselected.
@@ -173,10 +167,9 @@ message SurveyInfo {
 
     // Required.
     // A pronounceable explanation of the legal implications of participating in the survey.
-    // For example:
-    //  "Your answers during this survey will be stored anonymously for the next two years and then deleted."
+    // For example: &quot;Your answers during this survey will be stored anonymously for the next two years and then deleted.&quot;
     // Should be formulated such that the agent can afterwards ask for the consent of the user.
-    // Example for how the agent could continue: "Are you willing to participate in this survey?"
+    // Example for how the agent could continue: &quot;Are you willing to participate in this survey?&quot;
     string legal_disclaimer = 9;
 
     // Optional.
@@ -187,12 +180,13 @@ message SurveyInfo {
 }
 
 
-// Enumeration of (some of) the subflows which are created by default
-// This can be used to "switch off" particular subflows when creating an agent during CreateSurvey
-// Subflows are defined as one of the following:
-// - sequences of intents A -> B_1, ..., B_n -> ... -> Z_1, ..., Z_m which are linked by context relationships
-//      such that the first intent in the sequence can always be triggered
-// - single intents which can always be triggered
+// <p>Enumeration of (some of) the subflows which are created by default</p>
+// <p>This can be used to &quot;switch off&quot; particular subflows when creating an agent during CreateSurvey</p>
+// <p>Subflows are defined as one of the following:</p>
+// <ul>
+//   <li>sequences of intents A -&gt; B_1, ..., B_n -&gt; ... -&gt; Z_1, ..., Z_m which are linked by context relationships such that the first intent in the sequence can always be triggered</li>
+//   <li>single intents which can always be triggered</li>
+// </ul>
 enum SubFlow {
     // Not specified. This value should be never used.
     SUBFLOW_UNSPECIFIED = 0;
@@ -228,29 +222,23 @@ message Question {
         OpenQuestion open_question = 1;
         SingleChoiceQuestion single_choice_question = 2;
         MultipleChoiceQuestion multiple_choice_question = 3;
-        ScaleQuestion scale_question = 4; // convenience wrapper around a SingleChoiceQuestion
+        // convenience wrapper around a SingleChoiceQuestion
+        ScaleQuestion scale_question = 4;
         SingleParameterQuestion single_parameter_question = 5;
         MultipleParameterQuestion multiple_parameter_question = 6;
     }
 }
 
 
-// A question to which any kind of reply can be given and recorded
-// fixme: not working yet
+// <p>A question to which any kind of reply can be given and recorded</p>
+// <p>fixme: not working yet</p>
 message OpenQuestion {
     // The text which introduces the question (should be pronounceable)
     string question_text = 1;
 }
 
-// A question for which exactly one out of a predefined set of options is expected as answer
-// Example: SingleChoiceQuestion(
-//      question_text='Who is your favorite movie hero?',
-//      choices=[
-//          Choice(synonyms=['Bond', 'James Bond']),
-//          Choice(synonyms=['Batman']),
-//          Choice(synonyms=['Superman', 'Clark Kent']),
-//          ]
-//      )
+// <p>A question for which exactly one out of a predefined set of options is expected as answer</p>
+// <p>Example: <code>SingleChoiceQuestion(question_text=&apos;Who is your favorite movie hero?&apos;, choices=[Choice(synonyms=[&apos;Bond&apos;, &apos;James Bond&apos;]), Choice(synonyms=[&apos;Batman&apos;]), Choice(synonyms=[&apos;Superman&apos;, &apos;Clark Kent&apos;])])</code></p>
 message SingleChoiceQuestion {
     // The text which introduces the question (should be pronounceable)
     string question_text = 1;
@@ -261,15 +249,8 @@ message SingleChoiceQuestion {
     repeated Choice choices = 2;
 }
 
-// A question for which exactly one or more out of a predefined set of options are expected as answers
-// Example: MultipleChoiceQuestion(
-//      question_text='Which colors do you like?',
-//      choices=[
-//          Choice(synonyms=['red', 'reddisch']),
-//          Choice(synonyms=['blue', 'blueish']),
-//          Choice(synonyms=['yellow']),
-//          ]
-//       )
+// <p>A question for which exactly one or more out of a predefined set of options are expected as answers</p>
+// <p>Example: <code>MultipleChoiceQuestion(question_text=&apos;Which colors do you like?&apos;, choices=[Choice(synonyms=[&apos;red&apos;, &apos;reddisch&apos;]), Choice(synonyms=[&apos;blue&apos;, &apos;blueish&apos;]), Choice(synonyms=[&apos;yellow&apos;])])</code></p>
 message MultipleChoiceQuestion {
     // The text which introduces the question (should be pronounceable)
     string question_text = 1;
@@ -292,8 +273,8 @@ message ScaleQuestion {
     ScaleValue max_value = 3;
 }
 
-// SingleParameterQuestion defines a question which prompts the user for one entity of a particular type
-// Example: SingleParameterQuestion(question_text='How old are you?', parameter_type='sys.number')
+// <p>SingleParameterQuestion defines a question which prompts the user for one entity of a particular type</p>
+// <p>Example: <code>SingleParameterQuestion(question_text=&apos;How old are you?&apos;, parameter_type=&apos;sys.number&apos;)</code></p>
 message SingleParameterQuestion {
     // The text which introduces the question (should be pronounceable)
     string question_text = 1;
@@ -303,8 +284,8 @@ message SingleParameterQuestion {
     string parameter_type = 2;
 }
 
-// MultipleParameterQuestion defines a question which prompts the user for one or several entities of one particular type
-// Example: MultipleParameterQuestion(question_text='How old are your children?', parameter_type='sys.number')
+// <p>MultipleParameterQuestion defines a question which prompts the user for one or several entities of one particular type</p>
+// <p>Example: <code>MultipleParameterQuestion(question_text=&apos;How old are your children?&apos;, parameter_type=&apos;sys.number&apos;)</code></p>
 message MultipleParameterQuestion {
     // The text which introduces the question (should be pronounceable)
     string question_text = 1;
@@ -314,8 +295,8 @@ message MultipleParameterQuestion {
     string parameter_type = 2;
 }
 
-// The Choice message defines one "option" for the SingleChoiceQuestion and MultipleChoiceQuestion question types
-// Example: Choice(synonyms=["blue", "blueish", "pale blue", "deep blue"])
+// <p>The Choice message defines one &quot;option&quot; for the SingleChoiceQuestion and MultipleChoiceQuestion question types</p>
+// <p>Example: <code>Choice(synonyms=[&quot;blue&quot;, &quot;blueish&quot;, &quot;pale blue&quot;, &quot;deep blue&quot;])</code></p>
 message Choice {
     // The synonyms which are recognized as equivalent for identifying one option
     repeated string synonyms = 1;
@@ -324,7 +305,7 @@ message Choice {
     // Note: the follow-up question is only available for the SingleChoiceQuestion
     Question follow_up_question = 2;
 
-    // The "canonical value" (i.e. the entity value)
+    // The &quot;canonical value&quot; (i.e. the entity value)
     string value = 3;
 }
 
@@ -373,7 +354,7 @@ message CreateSurveyRequest {
 
 message GetSurveyRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
@@ -382,14 +363,13 @@ message UpdateSurveyRequest {
     Survey survey = 1;
 
     // Optional. Field mask that defines which fields get updated. Default: all fields are updated.
-    // Example:
-    //          - update_mask = FieldMask( [ 'survey.display_name', 'survey.questions' ] )
+    // Example: <code>update_mask = FieldMask([&apos;survey.display_name&apos;, &apos;survey.questions&apos;])</code>
     google.protobuf.FieldMask update_mask = 2;
 }
 
 message DeleteSurveyRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
@@ -408,45 +388,44 @@ message GetSurveyAnswersRequest {
 
 message GetAllSurveyAnswersRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
 message SurveyAnswersResponse {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
-    repeated Answer answers = 2; // all requested answers
+    // all requested answers
+    repeated Answer answers = 2;
 }
 
 message ListSurveysRequest {
     // Optional. The next_page_token value returned from a previous list request.
     // Example:
-    //      "current_index-10--page_size-20"
-    //      Start page -> 10
-    //      Page size -> 20
+    // <ul>
+    //   <li>&quot;current_index-10--page_size-20&quot; - Start page -&gt; 10, Page size -&gt; 20</li>
+    // </ul>
     string page_token = 1;
 }
 
-// The response message for [Intents.ListIntents][google.cloud.dialogflow.v2.Intents.ListIntents].
+// <p>The response message for <a href="index.html#google.cloud.dialogflow.v2.Intents.ListIntents">Intents.ListIntents</a>.</p>
 message ListSurveysResponse {
-    // The list of surveys. There will be a maximum number of items
-    // returned based on the page_token field in the request.
+    // The list of surveys. There will be a maximum number of items returned based on the page_token field in the request.
     repeated Survey surveys = 1;
 
-    // Token to retrieve the next page of results, or empty if there are no
-    // more results in the list.
+    // Token to retrieve the next page of results, or empty if there are no more results in the list.
     string next_page_token = 2;
 }
 
 message AgentSurveyRequest {
     // The project identifier for this survey. Equal to the parent of the corresponding Agent.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string survey_id = 1;
 }
 
 message AgentSurveyResponse {
     // The parent of an agent. Equal to the survey ID.
-    // Format: `projects/<Project ID>/agent`.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     string parent = 1;
 }


### PR DESCRIPTION
### This PR improves documentation generation and consistency across proto files by:

Adding dedicated documentation build targets to the **Makefile** to simplify and standardise the docs build process.

Updating all comments in `survey.proto` and `fhir.proto` to use valid HTML formatting instead of Markdown, ensuring correct rendering in HTML-based proto documentation tools.